### PR TITLE
Revert "Allow user-specified background defaults per channel (#6)"

### DIFF
--- a/src/pwarp/demo/demo_with_more_channels.py
+++ b/src/pwarp/demo/demo_with_more_channels.py
@@ -222,12 +222,9 @@ class DemoWithTransparency(object):
                     new_vertices_t = self.shift_and_scale(new_vertices)
                     if self.transform_image:
                         sorted_faces = misc.sort_faces(self.faces, self.vertices, self.vertices[self.moving_index, :])
-                        default_fill_color = np.zeros(self.img.shape[2], dtype=np.uint8)
                         self.img = warp.graph_defined_warp(
                             self.img, self.vertices_t, sorted_faces, new_vertices_t, sorted_faces,
-                            support_deep_images=True,
-                            default_fill_color=default_fill_color,
-                        )
+                            support_deep_images=True)
                         self._transformed_background = self.img.copy()
                         mask = self.img[:,:,3].reshape(self.img.shape[0], self.img.shape[1], 1) / 255.0
                         self.img = self._bg_img * (1 - mask) + self.img[:,:,:3]

--- a/src/pwarp/warp/warp.py
+++ b/src/pwarp/warp/warp.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, Tuple, Union
+from typing import Union, Iterable, Tuple
 
 import cv2
 import numpy as np
@@ -181,8 +181,6 @@ def _crop_to_origin(
         bbox: Tuple[int, int, int, int],
         origin_w: Union[int, dtype.INT],
         origin_h: Union[int, dtype.INT],
-        use_alpha: bool = False,
-        default_fill_color: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """
     Some traget vertices of transformed mesh might be outside of original iamge boundaries.
@@ -194,23 +192,12 @@ def _crop_to_origin(
     :param image: np.ndarray;
     :param origin_w: Union[int, dtype.INT];
     :param origin_h: Union[int, dtype.INT];
-    :param use_alpha: bool;
-    :param default_fill_color: Optional[np.ndarray];
     :return: np.ndarray;
     """
     dx, dy, bbox_w, bbox_h = bbox
-    # Create base image.
-    num_channels = image.shape[2] if not use_alpha else 4
-    if default_fill_color is None:
-        fill_color = 0 if use_alpha else 255
-    else:
-        fill_color = np.concatenate(
-            (default_fill_color,
-             [0 if use_alpha else 255] *
-             (num_channels - len(default_fill_color)))
-        )
-    base_image = np.full((origin_h, origin_w, image.shape[2]),
-                         fill_color, dtype=np.uint8)
+    # Create base white image.
+    has_alpha = image.shape[2] == 4
+    base_image = np.full((origin_h, origin_w, image.shape[2]), 0 if has_alpha else 255, dtype=dtype.UINT8)
     slicer = np.zeros((2, 4), dtype=dtype.INT32)
     deltas, shape, bbox_shape = (dx, dy), (origin_w, origin_h), (bbox_w, bbox_h)
 
@@ -270,7 +257,6 @@ def graph_defined_warp(
         faces_dst: np.ndarray,
         use_scikit: Union[dtype.BOOL, bool] = False,
         support_deep_images: Union[dtype.BOOL, bool] = False,
-        default_fill_color: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """
     Based on triangulated shape transformed from source to destination mesh
@@ -284,8 +270,6 @@ def graph_defined_warp(
     :param vertices_dst: np.ndarray;
     :param faces_dst: np.ndarray;
     :param use_scikit: bool;
-    :param support_deep_images: bool;
-    :param default_fill_color: Optional[np.ndarray];
     :return: np.ndarray;
     """
     # Create white image of shape of vertices bonding box.
@@ -301,17 +285,11 @@ def graph_defined_warp(
     use_alpha = image.shape[2] == 4
     if support_deep_images:
         use_alpha = False
-    num_channels = image.shape[2] if support_deep_images else 3 + use_alpha
-    if default_fill_color is None:
-        fill_color = 0 if use_alpha else 255
-    else:
-        fill_color = np.concatenate(
-            (default_fill_color,
-             [0 if use_alpha else 255] *
-             (num_channels - len(default_fill_color)))
-        )
-    bbox_base_image = np.full((bbox_h, bbox_w, num_channels), fill_color,
-                              dtype=np.uint8)
+    bbox_base_image = np.full(
+        (bbox_h, bbox_w, image.shape[2] if support_deep_images else 3 + use_alpha),
+        0 if use_alpha else 255,
+        dtype=dtype.UINT8
+    )
 
     # Iterate over all faces.
     for f_src, f_dst in zip(faces_src, faces_dst):
@@ -332,7 +310,7 @@ def graph_defined_warp(
             bbox_base_image = _broadcast_transformed_tri(bbox_base_image, bbox, warped, alpha)
 
     # Broadcast proper part of transformed bbox image to iamge of original shape.
-    base_image = _crop_to_origin(bbox_base_image, (dx, dy, bbox_w, bbox_h), width, height, use_alpha, default_fill_color)
+    base_image = _crop_to_origin(bbox_base_image, (dx, dy, bbox_w, bbox_h), width, height)
 
     return base_image
 


### PR DESCRIPTION
This reverts commit `3fc040e33a266fc298e24e7b8073e233ef81dcfe` since we no longer have a need for this functionality and have never used it.