### PR TITLE
chore: remove non-headless opencv-python (VTOS-293)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Requirements
 ::
 
     numpy>=1.21.5
-    opencv-contrib-python>=4.5.4.60,<=4.11.0.86
+    opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86
     scikit-image>=0.19.2,<=0.25.1
     scikit-learn>=1.0.2,<=1.6.1
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,6 @@ Requirements
 
     numpy>=1.21.5
     opencv-contrib-python>=4.5.4.60,<=4.11.0.86
-    opencv-python>=4.5.4.60,<=4.11.0.86
     scikit-image>=0.19.2,<=0.25.1
     scikit-learn>=1.0.2,<=1.6.1
 

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,9 @@ Requirements
 
     numpy>=1.21.5
     opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86
+    # Swap out the headless opencv above for the following
+    # headed version if you want to run the demo
+    # opencv-python>=4.5.4.60,<=4.11.0.86
     scikit-image>=0.19.2,<=0.25.1
     scikit-learn>=1.0.2,<=1.6.1
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 numpy>=1.21.5
 opencv-contrib-python>=4.5.4.60,<=4.7.0.72
-opencv-python>=4.5.4.60,<=4.7.0.72
 scikit-image>=0.19.2,<=0.21.0
 scikit-learn>=1.0.2,<=1.2.2
 triangle>=20200424

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,9 @@
 numpy>=1.21.5
 opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86
+# Swap out the headless opencv above for the following
+# headed versions if you want to run the demo
+# opencv-contrib-python>=4.5.4.60,<=4.11.0.86
+# opencv-python>=4.5.4.60,<=4.11.0.86
 scikit-image>=0.19.2,<=0.25.1
 scikit-learn>=1.0.2,<=1.6.1
 git+https://github.com/drufat/triangle.git#20230923

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
 numpy>=1.21.5
-opencv-contrib-python>=4.5.4.60,<=4.7.0.72
-scikit-image>=0.19.2,<=0.21.0
-scikit-learn>=1.0.2,<=1.2.2
-triangle>=20200424
+opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86
+scikit-image>=0.19.2,<=0.25.1
+scikit-learn>=1.0.2,<=1.6.1
+git+https://github.com/drufat/triangle.git#20230923
 
 Sphinx==4.4.0
 sphinx-rtd-theme==1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ classifiers = [
 dependencies = [
   "numpy>=1.21.5",
   "opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86",
+  # Swap out the headless opencv above for the following
+  # headed version if you want to run the demo
+  # "opencv-python>=4.5.4.60,<=4.11.0.86",
   "scikit-image>=0.19.2,<=0.25.1",
   "scikit-learn>=1.0.2,<=1.6.1"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 
 dependencies = [
   "numpy>=1.21.5",
-  "opencv-contrib-python>=4.5.4.60,<=4.11.0.86",
+  "opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86",
   "scikit-image>=0.19.2,<=0.25.1",
   "scikit-learn>=1.0.2,<=1.6.1"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
 dependencies = [
   "numpy>=1.21.5",
   "opencv-contrib-python>=4.5.4.60,<=4.11.0.86",
-  "opencv-python>=4.5.4.60,<=4.11.0.86",
   "scikit-image>=0.19.2,<=0.25.1",
   "scikit-learn>=1.0.2,<=1.6.1"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.21.5
-opencv-contrib-python>=4.5.4.60,<=4.11.0.86
+opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86
 scikit-image>=0.19.2,<=0.25.1
 scikit-learn>=1.0.2,<=1.6.1
 git+https://github.com/drufat/triangle.git#20230923

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 numpy>=1.21.5
 opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86
+# Swap out the headless opencv above for the following
+# headed versions if you want to run the demo
+# opencv-contrib-python>=4.5.4.60,<=4.11.0.86
+# opencv-python>=4.5.4.60,<=4.11.0.86
 scikit-image>=0.19.2,<=0.25.1
 scikit-learn>=1.0.2,<=1.6.1
 git+https://github.com/drufat/triangle.git#20230923

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy>=1.21.5
 opencv-contrib-python>=4.5.4.60,<=4.11.0.86
-opencv-python>=4.5.4.60,<=4.11.0.86
 scikit-image>=0.19.2,<=0.25.1
 scikit-learn>=1.0.2,<=1.6.1
 git+https://github.com/drufat/triangle.git#20230923

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,9 @@ setup(
     install_requires=[
         'numpy>=1.21.5',
         'opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86',
+        # Swap out the headless opencv above for the following
+        # headed version if you want to run the demo
+        # 'opencv-python-headless>=4.5.4.60,<=4.11.0.86',
         'scikit-image>=0.19.2,<=0.25.1',
         'scikit-learn>=1.0.2,<=1.6.1',
     ],

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,6 @@ setup(
     install_requires=[
         'numpy>=1.21.5',
         'opencv-contrib-python-headless>=4.5.4.60,<=4.11.0.86',
-        'opencv-python-headless>=4.5.4.60,<=4.11.0.86',
         'scikit-image>=0.19.2,<=0.25.1',
         'scikit-learn>=1.0.2,<=1.6.1',
     ],


### PR DESCRIPTION
This was causing issues where a build would require libGL and I traced it back to multiple versions (out of contrib/vanilla and headless/vanilla) of opencv being available.

This removes the opencv-python (non-headless) version, but leaves the headed versions in for the demo if anyone is interested in running that.